### PR TITLE
Add definition for sendClick method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -803,6 +803,18 @@ declare module 'vatom-spaces-plugins' {
         toggleFollow(id: string): void
 
         /**
+         * Sends a click to the object matching the given identifier.
+         *
+         * **Note**: When using this method, the object that needs to be clicked
+         * should be within rendering range, otherwise the click will not be sent
+         * to that object.
+         *
+         * @param id Identifier of the object to send a click to.
+         * @returns `true` if the click was sent to the object, `false` otherwise.
+         */
+        sendClick(id: string): boolean
+
+        /**
          * Registers the specified animations with the system.
          * @param url URL of the animations that you wish to register.
          */

--- a/index.d.ts
+++ b/index.d.ts
@@ -812,7 +812,7 @@ declare module 'vatom-spaces-plugins' {
          * @param id Identifier of the object to send a click to.
          * @returns `true` if the click was sent to the object, `false` otherwise.
          */
-        sendClick(id: string): boolean
+        sendClick(id: string): Promise<boolean>
 
         /**
          * Registers the specified animations with the system.


### PR DESCRIPTION
**NB**: Should not be merged in until PR [#2184](https://github.com/VatomInc/speakeasy/pull/2184) is in prod

Adds the definition for a new method `this.objects.sendClick` that allows plugins to send a click event to an object