### PR TITLE
Allow external plugins to set tilt value of current user

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -402,6 +402,16 @@ declare module 'vatom-spaces-plugins' {
         uv: Vector2
     }
 
+    /** Options relating to setting the view mode */
+    interface ViewModeOptions {
+        /** Configuration options for the given view mode. Available fields are dependent on the given view mode. */
+        config: object,
+        /** `true` to enable fullscreen mode, `false` to exit fullscreen mode. */
+        fullscreen: boolean,
+        /** `true` to request pointer lock (only supported in "first-person" view mode), `false` to exit pointer lock. */
+        pointerLock: boolean,
+    }
+
     /** Callback function for an input capture event */
     type InputCaptureCallback = (event: InputCaptureEvent) => void
 
@@ -966,16 +976,30 @@ declare module 'vatom-spaces-plugins' {
         /**
          * Gets the orientation of the current user.
          * @param deg `true` to return the orientation in degrees, `false` to return in radians. Default is `false`.
-         * @returns Orientation of the current user.
+         * @returns Orientation in radians (or degrees if `deg === true`).
          */
         getOrientation(deg: boolean = false): Promise<number>
 
         /**
          * Sets the orientation of the current user.
-         * @param o Orientation to set for the current user.
+         * @param orient Orientation to set for the current user.
          * @param deg `true` to indicate that the given orientation is in degrees, `false` to indicate that it is in radians. Default is `false`.
          */
-        setOrientation(o: number, deg: boolean = false): void
+        setOrientation(orient: number, deg: boolean = false): void
+
+        /**
+         * Gets the tilt value of the current user.
+         * @param deg `true` to return the tilt in degrees, `false` to return in radians. Default is `false`.
+         * @returns Tilt value in radians (or degrees if `deg === true`).
+         */
+        getTilt(deg: boolean = false): Promise<number>
+
+        /**
+         * Sets current user tilt.
+         * @param tilt Tilt value to set for the user.
+         * @param deg `true` to indicate that the given tilt is in degrees, `false` to indicate that it is in radians. Default is `false`.
+         */
+        setTilt(tilt: number, deg: boolean = false): void
 
         /**
          * Gets the zoom level of the current user.
@@ -999,9 +1023,10 @@ declare module 'vatom-spaces-plugins' {
         /**
          * Sets the view mode of the current user.
          * @param mode New view mode to use.
+         * @param options Options relating to the view mode.
          * @returns `true` if the view mode has been set successfully, `false` otherwise.
          */
-        setViewMode(mode: ViewMode): Promise<boolean>
+        setViewMode(mode: ViewMode, options?: ViewModeOptions): Promise<boolean>
 
         /** @returns Identifier of the current user */
         getID(): Promise<string>

--- a/index.d.ts
+++ b/index.d.ts
@@ -946,6 +946,9 @@ declare module 'vatom-spaces-plugins' {
     /** Handles the management of the user's position and appearance */
     class User {
 
+        /** @returns Position that the current user will be in when they enter the space */
+        getInitialPosition(): Promise<Vector3>
+
         /** @returns Position of the current user */
         getPosition(): Promise<Vector3>
 


### PR DESCRIPTION
**Note**: Should not be merged in until PR [#2258](https://github.com/VatomInc/speakeasy/pull/2258) is in prod.

Exposes the following methods to external plugins:
- `this.user.getInitialPosition()` - Returns the position that the user will be in when they enter the space
- `this.user.getTilt(deg = false)` - Returns the tilt value of the current user in radians (when `deg === false`) or degrees (when `deg === true`)
- `this.user.setTilt(tilt: number, deg = false)` - Sets the tilt value of the current user in radians (when `deg === false`) or degrees (when `deg === true`)
- `this.user.setViewMode(mode, options)` - Same as before but now with added parameter `options`, which can have fields `{ config, fullscreen, pointerLock }`