### PR TITLE
Allow plugins to check current user mute status

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1055,6 +1055,15 @@ declare module 'vatom-spaces-plugins' {
         /** @returns `true` if this user is an admin in the space, `false` otherwise */
         isAdmin(): Promise<boolean>
 
+        /** @returns `true` if this user is a super admin in the space, `false` otherwise */
+        isSuperAdmin(): Promise<boolean>
+
+        /** @returns `true` if this user is the owner of this space, `false` otherwise */
+        isOwner(): Promise<boolean>
+
+        /** @returns `true` if this user is currently muted, `false` otherwise */
+        isMuted(): Promise<boolean>
+
         /** @returns `true` if your user is following another user or object, `false` otherwise */
         getFollow(): Promise<boolean>
 


### PR DESCRIPTION
Adds the following methods:
- `user.isSuperAdmin()` - Used to check if the current user is a super admin
- `user.isOwner()` - Used to check if the current user is the owner of the space
- `user.isMuted()` - Used to check if the current user is muted or unmuted